### PR TITLE
Fix/70: Change namespaces to avoid conflicts

### DIFF
--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Create/CreateRelatedTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Create/CreateRelatedTermHandlerTests.cs
@@ -6,11 +6,11 @@ using Streetcode.BLL.DTO.Streetcode.TextContent;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Create;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.Fixtures;
+using Streetcode.XUnitTest.MediatR.RelatedTerm.Fixtures;
 using Xunit;
 using Entity = Streetcode.DAL.Entities.Streetcode.TextContent.RelatedTerm;
 
-namespace Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.Create;
+namespace Streetcode.XUnitTest.MediatR.RelatedTerm.Create;
 
 public class CreateRelatedTermHandlerTests
 {

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermHandlerTests.cs
@@ -6,11 +6,11 @@ using Streetcode.BLL.DTO.Streetcode.TextContent;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Delete;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.Fixtures;
+using Streetcode.XUnitTest.MediatR.RelatedTerm.Fixtures;
 using Xunit;
 using Entity = Streetcode.DAL.Entities.Streetcode.TextContent.RelatedTerm;
 
-namespace Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.Delete;
+namespace Streetcode.XUnitTest.MediatR.RelatedTerm.Delete;
 
 public class DeleteRelatedTermHandlerTests
 {

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Fixtures/RelatedTermMockExtensions.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Fixtures/RelatedTermMockExtensions.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using Entity = Streetcode.DAL.Entities.Streetcode.TextContent.RelatedTerm;
 
-namespace Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.Fixtures
+namespace Streetcode.XUnitTest.MediatR.RelatedTerm.Fixtures
 {
     public static class RelatedTermMockExtensions
     {

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/GetByTermId/GetByTermIdReletedTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/GetByTermId/GetByTermIdReletedTermHandlerTests.cs
@@ -6,11 +6,11 @@ using Streetcode.BLL.DTO.Streetcode.TextContent;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.GetAllByTermId;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.Fixtures;
+using Streetcode.XUnitTest.MediatR.RelatedTerm.Fixtures;
 using Xunit;
 using Entity = Streetcode.DAL.Entities.Streetcode.TextContent.RelatedTerm;
 
-namespace Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.GetByTermId;
+namespace Streetcode.XUnitTest.MediatR.RelatedTerm.GetByTermId;
 
 public class GetByTermIdRelatedTermsHandlerTests
 {

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Update/UpdateRelatedTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/RelatedTerm/Update/UpdateRelatedTermHandlerTests.cs
@@ -1,4 +1,4 @@
-namespace Streetcode.XUnitTest.MediatR.Streetcode.RelatedTerm.Update;
+namespace Streetcode.XUnitTest.MediatR.RelatedTerm.Update;
 
 public class UpdateRelatedTermHandlerTests
 {


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @VolodymyrShapoval 
- [x] @shribakb1 
- [ ] @LekhivOleh 

## Summary of issue

Build fails
#70 

## Summary of change

This pull request refactors namespace structure for unit tests related to `RelatedTerm` handlers in the `Streetcode.XUnitTest` project. The main change is the removal of the redundant `Streetcode` segment from the namespaces and folder paths under `MediatR`, resulting in a simpler and more consistent organization.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
