### PR TITLE
Refactor/84/fix issues dbupdate program file

### DIFF
--- a/Streetcode/DbUpdate/Program.cs
+++ b/Streetcode/DbUpdate/Program.cs
@@ -5,13 +5,19 @@
 
     public static class Program
     {
-        static int Main(string[] args)
+        public static int Main(string[] args)
         {
-            string migrationPath = Path.Combine(Directory.GetCurrentDirectory(),
-                "Streetcode.DAL", "Persistence", "ScriptsMigration");
+            string migrationPath = Path.Combine(
+                Directory.GetCurrentDirectory(),
+                "Streetcode.DAL",
+                "Persistence",
+                "ScriptsMigration");
 
-            string seedPath = Path.Combine(Directory.GetCurrentDirectory(),
-                "Streetcode.DAL", "Persistence", "ScriptsSeed");
+            string seedPath = Path.Combine(
+                Directory.GetCurrentDirectory(),
+                "Streetcode.DAL",
+                "Persistence",
+                "ScriptsSeed");
 
             var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Local";
 
@@ -24,8 +30,8 @@
 
             var connectionString = configuration.GetConnectionString("DefaultConnection");
 
-            string pathToScript = "";
-            string userInput = "";
+            string pathToScript = string.Empty;
+            string userInput = string.Empty;
 
             Console.WriteLine("Enter '-m' to MIGRATE or '-s' to SEED db:");
             if (userInput == "-m")


### PR DESCRIPTION
dev

## Code reviewers

- [x] @LekhivOleh 
- [x] @Ammoniy 

## Summary of issue

This is sub-issue #84 
For main issue #57 
Closes #84 

## Summary of change

The manual assignment `pathToScript = migrationPath;` was removed. The application now correctly evaluates the user's input (`-m` or `-s`) via `Console.ReadLine()` and conditionally sets `pathToScript` to either `migrationPath` or `seedPath`


## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
