### PR TITLE
Fix/213 Add exception handling to CreateStreetcodeHandler

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -79,7 +79,7 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.Create
             catch (Exception ex)
             {
                 _logger.LogError(request, ex.Message);
-                return Result.Fail(new Error(ex.Message));
+                return Result.Fail(new Error(ErrorMessages.StreetcodeCreationFailed));
             }
         }
 

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Post/CreateStreetcodeHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Post/CreateStreetcodeHandlerTests.cs
@@ -163,7 +163,7 @@
 
             Assert.True(result.IsFailed);
 
-            Assert.Equal(ErrorMessages.StreetcodeTestException, result.Errors[0].Message);
+            Assert.Equal(ErrorMessages.StreetcodeCreationFailed, result.Errors[0].Message);
         }
 
         [Fact]


### PR DESCRIPTION
dev
## GitHub

* [GitHub #213](https://github.com/project-studying-dotnet/Streetcode-Server-November-2025/issues/213)

## Code reviewers

- [ ] @LekhivOleh 
- [x] @shribakb1 
- [ ] @Vektor19 

### Second Level Review

- [ ] @DrFaust555

## Summary of issue

This pull request enhances error handling in the `CreateStreetcodeHandler` by wrapping the handler logic in a try-catch block. This ensures that any exceptions during streetcode creation are logged and a standardized error response is returned.

**Error handling improvements:**

* Wrapped the `Handle` method logic in a try-catch block to catch exceptions during streetcode creation and return a standardized error message. (`Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs`)
* Added logging of exceptions using `_logger.LogError` to help with debugging and monitoring. (`Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs`)

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
