### PR TITLE
fix/220: call methods to load env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,17 @@ REDIS_CONNECTION_STRING=
 # Database Docker Configuration
 DOCKER_USER_VALUE='DOCKER USER VALUE'
 DOCKER_DB_PASSWD='DOCKER DB PASSWORD'
+
+# === JWT SETTINGS ===
+JWT_SECRET_KEY=super_secret_key_change_me_1234567890
+JWT_ISSUER=StreetCode.Api
+JWT_AUDIENCE=StreetCode.Client
+
+# minutes
+JWT_ACCESS_TOKEN_EXPIRATION_MINUTES=15
+
+# minutes (7 days = 7 * 24 * 60)
+JWT_REFRESH_TOKEN_EXPIRATION_MINUTES=10080
+
+# true для prod, false для local http
+JWT_REQUIRE_HTTPS_METADATA=false

--- a/Streetcode/Streetcode.WebApi/Program.cs
+++ b/Streetcode/Streetcode.WebApi/Program.cs
@@ -1,24 +1,14 @@
 using Hangfire;
 using DotNetEnv;
-using Streetcode.BLL.Services.BlobStorageService;
 using Streetcode.WebApi.Extensions;
 using Streetcode.WebApi.Middleware;
-using Streetcode.WebApi.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
 
 Env.Load("../../.env");
 
-var dbServer = Environment.GetEnvironmentVariable("DB_SERVER");
-var dbPassword = Environment.GetEnvironmentVariable("DB_USER_PASSWORD");
-var dbUser = Environment.GetEnvironmentVariable("DB_USER");
-var dbName = Environment.GetEnvironmentVariable("DB_NAME");
-
-var connectionString =
-   $"Server={dbServer};Database={dbName};User Id={dbUser};Password={dbPassword};MultipleActiveResultSets=true;TrustServerCertificate=True;";
-
 builder.Configuration.AddEnvironmentVariables();
-builder.Configuration["ConnectionStrings:DefaultConnection"] = connectionString;
+builder.Configuration.LoadEnvironmentVariables();
 
 builder.Host.ConfigureApplication();
 builder.Services.AddApplicationServices(builder.Configuration);


### PR DESCRIPTION
dev
## Github

#220 

## Summary of change

This pull request introduces new JWT configuration settings and refactors how environment variables are loaded into the application. The main changes are the addition of JWT-related environment variables and the simplification of configuration loading in the application startup.

**JWT Configuration:**

* Added new JWT-related environment variables to `.env.example`, including `JWT_SECRET_KEY`, `JWT_ISSUER`, `JWT_AUDIENCE`, token expiration settings, and a flag for HTTPS metadata requirements.

**Environment Variable Loading Refactor:**

* Replaced manual construction of the database connection string in `Program.cs` with a call to `LoadEnvironmentVariables()`, streamlining configuration management and reducing code duplication.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
