### PR TITLE
fix/272: Fix validation constants usage for comment validators

### DIFF
--- a/Streetcode/Streetcode.BLL/Util/Validators/ValidationConstants.cs
+++ b/Streetcode/Streetcode.BLL/Util/Validators/ValidationConstants.cs
@@ -312,5 +312,21 @@ namespace Streetcode.BLL.Util.Validators
             /// </summary>
             public const int DescriptionMaxLength = 500;
         }
+
+        /// <summary>
+        /// Comment-specific validation constants.
+        /// </summary>
+        public static class Comment
+        {
+            /// <summary>
+            /// Comment content maximum length.
+            /// </summary>
+            public const int ContentMaxLength = 500;
+
+            /// <summary>
+            /// Comment author name maximum length.
+            /// </summary>
+            public const int AuthorNameMaxLength = 50;
+        }
     }
 }


### PR DESCRIPTION
dev
- GitHub Issue #272 
## Code reviewers
- [ ] @VolodymyrShapoval 
- [ ] @LekhivOleh 
- [ ] @Vektor19 
- [ ] @shribakb1 
## Summary of issue
Some validation constants used in comment validators were missing.
This issue adds the required constants to ensure validation works correctly and consistently.
## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
