### PR TITLE
test/219: add unit tests for delete and update handlers

### DIFF
--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/Delete/DeleteCommentHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/Delete/DeleteCommentHandlerTests.cs
@@ -1,0 +1,193 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comment.Delete
+{
+    using Ardalis.Specification;
+    using FluentAssertions;
+    using Moq;
+    using Streetcode.BLL.Interfaces.Logging;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.Delete;
+    using Streetcode.DAL.Entities.Streetcode;
+    using Streetcode.DAL.Repositories.Interfaces.Base;
+    using Streetcode.DAL.Repositories.Interfaces.Streetcode;
+    using Streetcode.XUnitTest.Helpers;
+    using Streetcode.XUnitTest.MediatR.Comments.Fixtures;
+    using Streetcode.XUnitTest.MediatR.Comments.Helpers;
+    using Xunit;
+
+    public class DeleteCommentHandlerTests
+    {
+        private readonly Mock<IRepositoryWrapper> repositoryWrapperMock;
+        private readonly Mock<ILoggerService> loggerMock;
+        private readonly DeleteCommentHandler handler;
+
+        public DeleteCommentHandlerTests()
+        {
+            this.repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+            this.loggerMock = new Mock<ILoggerService>();
+            this.handler = new DeleteCommentHandler(
+                this.repositoryWrapperMock.Object,
+                this.loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnFailure_WhenCommentDoesNotExist()
+        {
+            // Arrange
+            var commentId = 999;
+            var command = new DeleteCommentCommand(commentId);
+            var commentsRepoMock = this.SetupRepositoryMock();
+            commentsRepoMock.SetupGetFirstOrDefaultAsync((Comment?)null);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Should().NotBeEmpty();
+            commentsRepoMock.VerifyGetFirstOrDefaultCalledOnce();
+            this.repositoryWrapperMock.VerifySaveChangesAsyncCalledNever();
+        }
+
+        [Fact]
+        public async Task Handle_ShouldHardDeleteComment_WhenCommentHasNoChildren()
+        {
+            // Arrange
+            var comment = CommentTestData.CreateComment();
+            comment.ParentCommentId = null;
+            var command = new DeleteCommentCommand(comment.Id);
+
+            var commentsRepoMock = this.SetupBasicDeleteScenario(comment, hasChildren: false);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            commentsRepoMock.Verify(x => x.Delete(comment), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldSoftDeleteComment_WhenCommentHasChildren()
+        {
+            // Arrange
+            var comment = CommentTestData.CreateComment();
+            comment.IsDeleted = false;
+            var command = new DeleteCommentCommand(comment.Id);
+
+            var commentsRepoMock = this.SetupBasicDeleteScenario(comment, hasChildren: true);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            comment.IsDeleted.Should().BeTrue();
+            comment.DeletedAt.Should().NotBeNull();
+            commentsRepoMock.VerifyUpdateCalledOnce(comment);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldCleanupParentChain_WhenParentIsDeletedAndHasNoChildren()
+        {
+            // Arrange
+            var parentComment = CommentTestData.CreateComment();
+            parentComment.Id = 1;
+            parentComment.IsDeleted = true;
+
+            var childComment = CommentTestData.CreateComment();
+            childComment.Id = 2;
+            childComment.ParentCommentId = parentComment.Id;
+
+            var command = new DeleteCommentCommand(childComment.Id);
+
+            var commentsRepoMock = this.SetupParentCleanupScenario(childComment, parentComment);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            commentsRepoMock.Verify(x => x.Delete(It.IsAny<Comment>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Handle_ShouldNotCleanupParent_WhenParentIsNotDeleted()
+        {
+            // Arrange
+            var parentComment = CommentTestData.CreateComment();
+            parentComment.Id = 1;
+            parentComment.IsDeleted = false;
+
+            var childComment = CommentTestData.CreateComment();
+            childComment.Id = 2;
+            childComment.ParentCommentId = parentComment.Id;
+
+            var command = new DeleteCommentCommand(childComment.Id);
+
+            var commentsRepoMock = this.SetupParentCleanupScenario(childComment, parentComment);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            commentsRepoMock.Verify(x => x.Delete(It.IsAny<Comment>()), Times.Once);
+        }
+
+        // Helper methods
+        private Mock<ICommentsRepository> SetupRepositoryMock()
+        {
+            var commentsRepoMock = new Mock<ICommentsRepository>();
+            this.repositoryWrapperMock.SetupRepositoryWrapper(commentsRepoMock);
+            this.repositoryWrapperMock.SetupRepository(
+                r => r.CommentsRepository,
+                commentsRepoMock);
+            return commentsRepoMock;
+        }
+
+        private Mock<ICommentsRepository> SetupBasicDeleteScenario(Comment comment, bool hasChildren)
+        {
+            var commentsRepoMock = this.SetupRepositoryMock();
+
+            commentsRepoMock.SetupGetFirstOrDefaultAsync(comment);
+            commentsRepoMock.Setup(x => x.AnyAsync(
+                It.IsAny<ISpecification<Comment>>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(hasChildren);
+
+            if (hasChildren)
+            {
+                commentsRepoMock.SetupUpdate();
+            }
+            else
+            {
+                commentsRepoMock.SetupDelete<ICommentsRepository, Comment>();
+            }
+
+            this.repositoryWrapperMock.SetupSaveChangesAsync();
+
+            return commentsRepoMock;
+        }
+
+        private Mock<ICommentsRepository> SetupParentCleanupScenario(Comment child, Comment parent)
+        {
+            var commentsRepoMock = this.SetupRepositoryMock();
+
+            commentsRepoMock.SetupSequence(x => x.GetFirstOrDefaultAsync(
+                    It.IsAny<System.Linq.Expressions.Expression<Func<Comment, bool>>>(),
+                    It.IsAny<Func<System.Linq.IQueryable<Comment>,
+                        Microsoft.EntityFrameworkCore.Query.IIncludableQueryable<Comment, object>>>()))
+                .ReturnsAsync(child)
+                .ReturnsAsync(parent);
+
+            commentsRepoMock.Setup(x => x.AnyAsync(
+                    It.IsAny<ISpecification<Comment>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            commentsRepoMock.SetupDelete<ICommentsRepository, Comment>();
+            this.repositoryWrapperMock.SetupSaveChangesAsync();
+
+            return commentsRepoMock;
+        }
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/Helpers/CommentSetups.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/Helpers/CommentSetups.cs
@@ -1,6 +1,8 @@
 namespace Streetcode.XUnitTest.MediatR.Comments.Helpers
 {
+    using System.Linq.Expressions;
     using Moq;
+    using Streetcode.DAL.Entities.Streetcode;
     using Streetcode.DAL.Repositories.Interfaces.Base;
     using Streetcode.DAL.Repositories.Interfaces.Streetcode;
 
@@ -58,6 +60,89 @@ namespace Streetcode.XUnitTest.MediatR.Comments.Helpers
             repositoryWrapperMock
                 .Setup(rw => rw.CommentsRepository)
                 .Returns(commentsRepositoryMock.Object);
+        }
+
+        /// <summary>
+        /// Sets up the mocked <see cref="IRepositoryWrapper"/> to return the provided mocked repository
+        /// instance for the specified repository selector.
+        /// </summary>
+        /// <typeparam name="TRepo">The type of the repository to set up.</typeparam>
+        /// <param name="wrapperMock">The mocked repository wrapper.</param>
+        /// <param name="repoSelector">An expression selecting the repository property from the wrapper.</param>
+        /// <param name="repoMock">The mocked repository to be returned.</param>
+        public static void SetupRepository<TRepo>(
+            this Mock<IRepositoryWrapper> wrapperMock,
+            Expression<Func<IRepositoryWrapper, TRepo>> repoSelector,
+            Mock<TRepo> repoMock)
+        where TRepo : class
+        {
+            wrapperMock.Setup(repoSelector).Returns(repoMock.Object);
+        }
+
+        /// <summary>
+        /// Sets up the mocked <see cref="ICommentsRepository"/> Update method.
+        /// </summary>
+        /// <param name="commentsRepositoryMock">The mocked comments repository.</param>
+        public static void SetupUpdate(
+            this Mock<ICommentsRepository> commentsRepositoryMock)
+        {
+            commentsRepositoryMock
+                .Setup(r => r.Update(It.IsAny<Comment>()));
+        }
+
+        /// <summary>
+        /// Verifies that the mocked <see cref="ICommentsRepository.GetFirstOrDefaultAsync"/> method
+        /// was called exactly once.
+        /// </summary>
+        /// <param name="commentsRepositoryMock">The mocked comments repository.</param>
+        public static void VerifyGetFirstOrDefaultCalledOnce(
+            this Mock<ICommentsRepository> commentsRepositoryMock)
+        {
+            commentsRepositoryMock.Verify(
+                r => r.GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Comment, bool>>>(),
+                    null),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Verifies that the mocked <see cref="ICommentsRepository.Update"/> method
+        /// was called exactly once with a specific comment.
+        /// </summary>
+        /// <param name="commentsRepositoryMock">The mocked comments repository.</param>
+        /// <param name="comment">The comment that should have been updated.</param>
+        public static void VerifyUpdateCalledOnce(
+            this Mock<ICommentsRepository> commentsRepositoryMock,
+            Comment comment)
+        {
+            commentsRepositoryMock.Verify(
+                r => r.Update(comment),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Verifies that the mocked <see cref="ICommentsRepository.Update"/> method
+        /// was never called.
+        /// </summary>
+        /// <param name="commentsRepositoryMock">The mocked comments repository.</param>
+        public static void VerifyUpdateCalledNever(
+            this Mock<ICommentsRepository> commentsRepositoryMock)
+        {
+            commentsRepositoryMock.Verify(
+                r => r.Update(It.IsAny<Comment>()),
+                Times.Never);
+        }
+
+        /// <summary>
+        /// Sets up the mocked <see cref="IRepositoryWrapper.SaveChangesAsync"/> method to return 0,
+        /// indicating that no changes were saved.
+        /// </summary>
+        /// <param name="repositoryWrapperMock">The mocked repository wrapper.</param>
+        public static void SetupNotSaveChangesAsync(this Mock<IRepositoryWrapper> repositoryWrapperMock)
+        {
+            repositoryWrapperMock
+                .Setup(rw => rw.SaveChangesAsync())
+                .ReturnsAsync(0);
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/Update/UpdateCommentHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/Update/UpdateCommentHandlerTests.cs
@@ -1,0 +1,241 @@
+﻿namespace Streetcode.XUnitTest.MediatR.Comment.Update
+{
+    using AutoMapper;
+    using FluentAssertions;
+    using Moq;
+    using Streetcode.BLL.DTO.Streetcode.Comments;
+    using Streetcode.BLL.Interfaces.Logging;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.Update;
+    using Streetcode.DAL.Entities.Streetcode;
+    using Streetcode.DAL.Repositories.Interfaces.Base;
+    using Streetcode.DAL.Repositories.Interfaces.Streetcode;
+    using Streetcode.XUnitTest.Helpers;
+    using Streetcode.XUnitTest.MediatR.Comments.Fixtures;
+    using Streetcode.XUnitTest.MediatR.Comments.Helpers;
+    using Xunit;
+
+    public class UpdateCommentHandlerTests
+    {
+        private const string UpdatedContent = "Updated content";
+        private const string UpdatedAuthorName = "Updated Author";
+
+        private readonly Mock<IMapper> mapperMock;
+        private readonly Mock<IRepositoryWrapper> repositoryWrapperMock;
+        private readonly Mock<ILoggerService> loggerMock;
+        private readonly UpdateCommentHandler handler;
+
+        public UpdateCommentHandlerTests()
+        {
+            this.mapperMock = new Mock<IMapper>();
+            this.repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+            this.loggerMock = new Mock<ILoggerService>();
+            this.handler = new UpdateCommentHandler(
+                this.repositoryWrapperMock.Object,
+                this.mapperMock.Object,
+                this.loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldUpdateComment_WhenCommentExists()
+        {
+            // Arrange
+            var existingComment = CommentTestData.CreateComment();
+            var updateDto = new UpdateCommentDto
+            {
+                Id = existingComment.Id,
+                Content = UpdatedContent,
+                AuthorName = UpdatedAuthorName,
+            };
+            var command = new UpdateCommentCommand(updateDto);
+
+            var commentsRepoMock = new Mock<ICommentsRepository>();
+            this.repositoryWrapperMock.SetupRepositoryWrapper(commentsRepoMock);
+
+            commentsRepoMock.SetupGetFirstOrDefaultAsync(existingComment);
+
+            commentsRepoMock.SetupUpdate();
+            this.repositoryWrapperMock.SetupSaveChangesAsync();
+
+            this.mapperMock.SetupMapper(existingComment, new CommentDto
+            {
+                Id = existingComment.Id,
+                Content = updateDto.Content,
+                AuthorName = updateDto.AuthorName,
+                StreetcodeId = existingComment.StreetcodeId,
+                CreatedAt = existingComment.CreatedAt,
+            });
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value!.Content.Should().Be(UpdatedContent);
+            result.Value.AuthorName.Should().Be(UpdatedAuthorName);
+
+            // Verify
+            commentsRepoMock.VerifyGetFirstOrDefaultCalledOnce();
+            commentsRepoMock.VerifyUpdateCalledOnce(existingComment);
+            this.repositoryWrapperMock.VerifySaveChangesAsyncCalledOnce();
+            this.mapperMock.VerifyMapCalledOnce<CommentDto>();
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnFailure_WhenCommentDoesNotExist()
+        {
+            // Arrange
+            var updateDto = new UpdateCommentDto
+            {
+                Id = 999,
+                Content = UpdatedContent,
+                AuthorName = UpdatedAuthorName,
+            };
+            var command = new UpdateCommentCommand(updateDto);
+
+            var commentsRepoMock = new Mock<ICommentsRepository>();
+            this.repositoryWrapperMock.SetupRepositoryWrapper(commentsRepoMock);
+
+            commentsRepoMock.SetupGetFirstOrDefaultAsync((Comment?)null);
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Should().NotBeEmpty();
+
+            // Verify
+            commentsRepoMock.VerifyGetFirstOrDefaultCalledOnce();
+            commentsRepoMock.VerifyUpdateCalledNever();
+            this.repositoryWrapperMock.VerifySaveChangesAsyncCalledNever();
+            this.mapperMock.VerifyMapCalledNever<CommentDto>();
+        }
+
+        [Fact]
+        public async Task Handle_ShouldReturnFailure_WhenSaveChangesFails()
+        {
+            // Arrange
+            var existingComment = CommentTestData.CreateComment();
+            var updateDto = new UpdateCommentDto
+            {
+                Id = existingComment.Id,
+                Content = UpdatedContent,
+                AuthorName = UpdatedAuthorName,
+            };
+            var command = new UpdateCommentCommand(updateDto);
+
+            var commentsRepoMock = new Mock<ICommentsRepository>();
+            this.repositoryWrapperMock.SetupRepositoryWrapper(commentsRepoMock);
+
+            commentsRepoMock.SetupGetFirstOrDefaultAsync(existingComment);
+            commentsRepoMock.SetupUpdate();
+            this.repositoryWrapperMock.SetupNotSaveChangesAsync();
+
+            this.mapperMock.SetupMapper(existingComment, new CommentDto
+            {
+                Id = existingComment.Id,
+                Content = updateDto.Content,
+                AuthorName = updateDto.AuthorName,
+                StreetcodeId = existingComment.StreetcodeId,
+                CreatedAt = existingComment.CreatedAt,
+            });
+
+            // Act
+            var result = await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Should().NotBeEmpty();
+
+            // Verify
+            commentsRepoMock.VerifyGetFirstOrDefaultCalledOnce();
+            commentsRepoMock.VerifyUpdateCalledOnce(existingComment);
+            this.repositoryWrapperMock.VerifySaveChangesAsyncCalledOnce();
+            this.mapperMock.VerifyMapCalledNever<CommentDto>();
+
+            this.mapperMock.Verify(
+                x => x.Map(updateDto, existingComment),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldSetUpdatedAtToCurrentUtcTime_WhenUpdatingComment()
+        {
+            // Arrange
+            var existingComment = CommentTestData.CreateComment();
+            var updateDto = new UpdateCommentDto
+            {
+                Id = existingComment.Id,
+                Content = UpdatedContent,
+                AuthorName = UpdatedAuthorName,
+            };
+            var command = new UpdateCommentCommand(updateDto);
+            var beforeUpdate = DateTime.UtcNow;
+
+            var commentsRepoMock = new Mock<ICommentsRepository>();
+            this.repositoryWrapperMock.SetupRepositoryWrapper(commentsRepoMock);
+
+            commentsRepoMock.SetupGetFirstOrDefaultAsync(existingComment);
+            commentsRepoMock.SetupUpdate();
+            this.repositoryWrapperMock.SetupSaveChangesAsync();
+
+            this.mapperMock.Setup(m => m.Map(updateDto, existingComment));
+            this.mapperMock.SetupMapper(existingComment, new CommentDto());
+
+            // Act
+            await this.handler.Handle(command, CancellationToken.None);
+            var afterUpdate = DateTime.UtcNow;
+
+            // Assert
+            existingComment.UpdatedAt.Should().BeOnOrAfter(beforeUpdate);
+            existingComment.UpdatedAt.Should().BeOnOrBefore(afterUpdate);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldLogError_WhenCommentDoesNotExist()
+        {
+            // Arrange
+            var updateDto = new UpdateCommentDto { Id = 999 };
+            var command = new UpdateCommentCommand(updateDto);
+
+            var commentsRepoMock = new Mock<ICommentsRepository>();
+            this.repositoryWrapperMock.SetupRepositoryWrapper(commentsRepoMock);
+            commentsRepoMock.SetupGetFirstOrDefaultAsync((Comment?)null);
+
+            // Act
+            await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            this.loggerMock.Verify(
+                x => x.LogError(
+                    command,
+                    It.Is<string>(s => s.Contains("999"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ShouldLogError_WhenSaveChangesFails()
+        {
+            // Arrange
+            var existingComment = CommentTestData.CreateComment();
+            var updateDto = new UpdateCommentDto
+            {
+                Id = existingComment.Id,
+                Content = UpdatedContent,
+            };
+            var command = new UpdateCommentCommand(updateDto);
+
+            var commentsRepoMock = new Mock<ICommentsRepository>();
+            this.repositoryWrapperMock.SetupRepositoryWrapper(commentsRepoMock);
+
+            commentsRepoMock.SetupGetFirstOrDefaultAsync(existingComment);
+            this.repositoryWrapperMock.SetupNotSaveChangesAsync();
+
+            // Act
+            await this.handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            this.loggerMock.VerifyLogErrorCalledOnce();
+        }
+    }
+}


### PR DESCRIPTION
dev
## GitHub
- Github Issue #219 
## Code reviewers
- [x] @LekhivOleh 
- [ ] @VolodymyrShapoval 
- [ ] @Vektor19 
- [ ] @shribakb1 
## Summary of issue
Added comprehensive unit tests for `UpdateCommentHandler` and `DeleteCommentHandler` to improve code coverage and ensure correct behavior.

## Changes
- **UpdateCommentHandler Tests**: 
  - Comment update with valid data
  - Failure scenarios (not found, save failure)
  - Mapper and logger verification

- **DeleteCommentHandler Tests**:
  - Hard delete (no children)
  - Soft delete (has children)
  - Parent chain cleanup logic
  - Edge cases (parent not deleted, multiple generations)

- **Test Helpers**: Added helper methods to reduce code duplication and improve test maintainability
## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
