### PR TITLE
feat/238: add GetById query with replies and unit tests

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/CommentWithRepliesDto.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Streetcode/Comments/CommentWithRepliesDto.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Streetcode.BLL.DTO.Streetcode.Comments
+{
+	public class CommentWithRepliesDto
+	{
+		public int Id { get; set; }
+		public string Content { get; set; } = string.Empty;
+		public string AuthorName { get; set; } = string.Empty;
+		public int StreetcodeId { get; set; }
+		public DateTime CreatedAt { get; set; }
+		public List<CommentWithRepliesDto> Replies { get; set; } = new();
+	}
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetById/GetCommentByIdWithRepliesHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetById/GetCommentByIdWithRepliesHandler.cs
@@ -1,0 +1,37 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetById
+{
+	public class GetCommentByIdWithRepliesHandler : IRequestHandler<GetCommentByIdWithRepliesQuery, Result<CommentWithRepliesDto>>
+	{
+		private readonly IRepositoryWrapper _repositoryWrapper;
+		private readonly IMapper _mapper;
+
+		public GetCommentByIdWithRepliesHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper)
+		{
+			_repositoryWrapper = repositoryWrapper;
+			_mapper = mapper;
+		}
+
+		public async Task<Result<CommentWithRepliesDto>> Handle(GetCommentByIdWithRepliesQuery request, CancellationToken cancellationToken)
+		{
+			var comment = await _repositoryWrapper.CommentsRepository.GetFirstOrDefaultAsync(
+				predicate: c => c.Id == request.Id,
+				include: i => i.Include(c => c.Replies));
+
+			if (comment is null)
+			{
+				return Result.Fail($"Comment with id {request.Id} not found");
+			}
+
+			var responseDto = _mapper.Map<CommentWithRepliesDto>(comment);
+
+			return Result.Ok(responseDto);
+		}
+	}
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetById/GetCommentByIdWithRepliesQuery.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Comments/GetById/GetCommentByIdWithRepliesQuery.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Streetcode.Comments;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Comments.GetById
+{
+    public record GetCommentByIdWithRepliesQuery(int Id) : IRequest<Result<CommentWithRepliesDto>>;
+}

--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\Streetcode.DAL\Streetcode.DAL.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="DTO\Comments\" />
     <Folder Include="Mapping\Analytics\" />
     <Folder Include="MediatR\AdditionalContent\Tag\" />
     <Folder Include="Exceptions\" />

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/CommentsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/CommentsController.cs
@@ -2,6 +2,7 @@
 using Streetcode.BLL.DTO.Streetcode.Comments;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Create;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Delete;
+using Streetcode.BLL.MediatR.Streetcode.Comments.GetById;
 using Streetcode.BLL.MediatR.Streetcode.Comments.GetByStreetcodeId;
 using Streetcode.BLL.MediatR.Streetcode.Comments.Update;
 
@@ -32,5 +33,11 @@ namespace Streetcode.WebApi.Controllers.Streetcode
         {
             return HandleResult(await Mediator.Send(new DeleteCommentCommand(id)));
         }
-    }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetByIdWithReplies([FromRoute] int id)
+		{
+			return HandleResult(await Mediator.Send(new GetCommentByIdWithRepliesQuery(id)));
+		}
+	}
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/GetById/GetCommentByIdWithRepliesHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Comment/GetById/GetCommentByIdWithRepliesHandlerTests.cs
@@ -1,0 +1,78 @@
+﻿namespace Streetcode.XUnitTest.MediatR.StreetCode.Comments.GetById
+{
+    using System.Linq.Expressions;
+    using AutoMapper;
+    using FluentAssertions;
+    using Microsoft.EntityFrameworkCore.Query;
+    using Moq;
+    using Streetcode.BLL.DTO.Streetcode.Comments;
+    using Streetcode.BLL.MediatR.Streetcode.Comments.GetById;
+    using Streetcode.DAL.Entities.Streetcode;
+    using Streetcode.DAL.Repositories.Interfaces.Base;
+    using Xunit;
+
+    public class GetCommentByIdWithRepliesHandlerTests
+    {
+        private readonly Mock<IRepositoryWrapper> mockRepo;
+        private readonly Mock<IMapper> mockMapper;
+        private readonly GetCommentByIdWithRepliesHandler handler;
+
+        public GetCommentByIdWithRepliesHandlerTests()
+        {
+            this.mockRepo = new Mock<IRepositoryWrapper>();
+            this.mockMapper = new Mock<IMapper>();
+            this.handler = new GetCommentByIdWithRepliesHandler(this.mockRepo.Object, this.mockMapper.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ExistingId_ReturnsSuccessAndDto()
+        {
+            int commentId = 1;
+
+            var comment = new Comment
+            {
+                Id = commentId,
+                Content = "Main Comment",
+                Replies = new List<Comment>
+                {
+                    new Comment { Id = 2, Content = "Reply", StreetcodeId = 1 },
+                },
+                StreetcodeId = 1,
+            };
+
+            var commentDto = new CommentWithRepliesDto { Id = commentId, Content = "Main Comment" };
+
+            this.mockRepo.Setup(r => r.CommentsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Comment, bool>>>(),
+                It.IsAny<Func<IQueryable<Comment>, IIncludableQueryable<Comment, object>>>()))
+                .ReturnsAsync(comment);
+
+            this.mockMapper.Setup(m => m.Map<CommentWithRepliesDto>(comment))
+                .Returns(commentDto);
+
+            var query = new GetCommentByIdWithRepliesQuery(commentId);
+
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Content.Should().Be("Main Comment");
+        }
+
+        [Fact]
+        public async Task Handle_NonExistingId_ReturnsFail()
+        {
+            int commentId = 999;
+
+            this.mockRepo.Setup(r => r.CommentsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Comment, bool>>>(),
+                It.IsAny<Func<IQueryable<Comment>, IIncludableQueryable<Comment, object>>>()))
+                .ReturnsAsync((Comment?)null);
+
+            var query = new GetCommentByIdWithRepliesQuery(commentId);
+
+            var result = await this.handler.Handle(query, CancellationToken.None);
+
+            result.IsFailed.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Code reviewers
- [x] @LekhivOleh 
- [ ] @VolodymyrShapoval 
- [ ] @Vektor19 
- [x] @shribakb1
- [ ] @Ammoniy
- [ ] @ArturOleksiuk

## Summary of issue
Implemented the functionality to retrieve a specific comment by its unique identifier, including all its nested replies. This feature is necessary for the admin panel to allow reviewing entire conversation threads.

## Summary of change
- **DTO**: Created `CommentWithRepliesDto` to support the recursive structure of comments and their replies.
- **CQRS**: Implemented `GetCommentByIdWithRepliesQuery` and its corresponding `Handler`.
- **Database**: Used `.Include(c => c.Replies)` in the repository call to efficiently fetch the comment hierarchy.
- **API**: Added a new `[HttpGet("{id}")]` endpoint to `CommentController`.
- **Tests**: Added unit tests to `Streetcode.XUnitTest` covering:
  - Successful retrieval of a comment with replies.
  - Error handling when the comment is not found.

## Testing approach
- **Unit Testing**: Wrote xUnit tests using Moq to verify the Handler logic, ensuring correct mapping and repository interaction.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
