### PR TITLE
Fix/281: Fix sonar reliability issues

### DIFF
--- a/Streetcode/Services/Streetcode.Auth/Streetcode.Auth.Api/Program.cs
+++ b/Streetcode/Services/Streetcode.Auth/Streetcode.Auth.Api/Program.cs
@@ -60,4 +60,4 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-app.Run();
+await app.RunAsync();

--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
@@ -67,7 +67,7 @@ namespace Streetcode.BLL.Services.BlobStorageService
             var container = await GetContainerAsync();
             var blobClient = container.GetBlobClient(name);
 
-            if (!blobClient.Exists())
+            if (!await blobClient.ExistsAsync())
             {
                 throw new FileNotFoundException(string.Format(ErrorMessages.BlobNotFoundByName, name));
             }
@@ -97,7 +97,7 @@ namespace Streetcode.BLL.Services.BlobStorageService
             var container = await GetContainerAsync();
             var blobClient = container.GetBlobClient(name);
 
-            if (!blobClient.DeleteIfExists())
+            if (!await blobClient.DeleteIfExistsAsync())
             {
                 throw new FileNotFoundException(string.Format(ErrorMessages.BlobNotFoundByName, name));
             }
@@ -106,7 +106,7 @@ namespace Streetcode.BLL.Services.BlobStorageService
         public async Task<bool> BlobExistsAsync(string blobName)
         {
             var container = await GetContainerAsync();
-            return container.GetBlobClient(blobName).Exists();
+            return await container.GetBlobClient(blobName).ExistsAsync();
         }
 
         private async Task<BlobContainerClient> GetContainerAsync()

--- a/Streetcode/Streetcode.BLL/Util/BlobHelper.cs
+++ b/Streetcode/Streetcode.BLL/Util/BlobHelper.cs
@@ -1,8 +1,8 @@
 namespace Streetcode.BLL.Util
 {
-    public class BlobHelper
+    public static class BlobHelper
     {
-        public static readonly Dictionary<string, string> MimeToExtension = new()
+        private static readonly Dictionary<string, string> _mimeToExtension = new()
         {
             // Images
             ["image/png"] = ".png",
@@ -16,6 +16,8 @@ namespace Streetcode.BLL.Util
             ["audio/mp3"] = ".mp3",
             ["audio/wav"] = ".wav"
         };
+
+        public static IReadOnlyDictionary<string, string> MimeToExtension => _mimeToExtension;
 
         public static string GetExtensionFromMimeType(string mimeType)
         {

--- a/Streetcode/Streetcode.DAL/Enums/UserRole.cs
+++ b/Streetcode/Streetcode.DAL/Enums/UserRole.cs
@@ -1,11 +1,11 @@
-﻿namespace Streetcode.DAL.Enums
+namespace Streetcode.DAL.Enums
 {
     [Flags]
     public enum UserRole
     {
-        None,
-        MainAdministrator,
-        Administrator,
-        Moderator
+        None = 0,
+        MainAdministrator = 1,
+        Administrator = 2,
+        Moderator = 3
     }
 }


### PR DESCRIPTION
dev

Closes #281 

## Summary of issue

Sonar addresses 6 reliability issues:
<img width="1161" height="1114" alt="image" src="https://github.com/user-attachments/assets/394b63cb-a980-4a24-b365-7f3e7056aae7" />

## Summary of change

1) Changed Auth.Api program class to RunAsync instead of Run as it is generally a better practice, and sonar warned about it.
2) Fix remaining non-asyncronymous methods in AzureBlobStorage service. Make them async to match rest of architecture
3) Fix issue about mutable readonly dictionary in BlobHelpers class. Make dictionary's purpose clear, private and then create getter for it.
4) Fix flags enumeration warning in UserRole enum, as it didn't initialize members (they didn't have numbers assigned, which can cause to different unexpected issues later)
<img width="1118" height="627" alt="image" src="https://github.com/user-attachments/assets/e4d9eb95-c15b-4fdd-943c-4dcd55ecdab5" />

## Testing approach

<img width="1135" height="229" alt="image" src="https://github.com/user-attachments/assets/1001452a-3bb1-4697-bfb2-5de2ab885c9f" />
Should be good to go

## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
