### PR TITLE
288-hotfix-fix-createstreetcodehandler

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/CreateStreetcodeHandler.cs
@@ -31,6 +31,9 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.Create
 
         public async Task<Result<JsonElement>> Handle(CreateStreetcodeCommand request, CancellationToken cancellationToken)
         {
+            using var transaction = new TransactionScope(
+                TransactionScopeAsyncFlowOption.Enabled);
+
             try
             {
                 var rawJson = request.rawJsonCreateDTO;
@@ -70,11 +73,22 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.Create
                     return tagsResult;
                 }
 
-                await _repository.SaveChangesAsync();
+                var resultIsSuccess = await _repository.SaveChangesAsync() > 0;
 
-                var streetcodeDTO = _mapper.Map<CreateStreetcodeDto>(streetcodeContent);
-                var jsonResult = JsonSerializer.SerializeToElement(streetcodeDTO);
-                return Result.Ok(jsonResult);
+                transaction.Complete();
+
+                if (resultIsSuccess)
+                {
+                    await _repository.SaveChangesAsync();
+
+                    var streetcodeDTO = _mapper.Map<CreateStreetcodeDto>(streetcodeContent);
+                    var jsonResult = JsonSerializer.SerializeToElement(streetcodeDTO);
+                    return Result.Ok(jsonResult);
+                }
+                else
+                {
+                    return Result.Fail(ErrorMessages.StreetcodeCreationFailed);
+                }
             }
             catch (Exception ex)
             {

--- a/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Helpers/StreetcodeHandlersTestsHelper.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatR/Streetcode/Helpers/StreetcodeHandlersTestsHelper.cs
@@ -189,7 +189,7 @@
             bool tagsIncluded = false,
             int times = 0)
         {
-            this.repositoryMock.VerifySaveChangesAsyncCalledTimes(2);
+            this.repositoryMock.VerifySaveChangesAsyncCalledTimes(3);
 
             this.mapperMock
                 .VerifyMapCalledOnce<StreetcodeContent>();


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @LausDio 
- [ ] @ArturOleksiuk 
- [ ] @VolodymyrShapoval 
- [x] @LekhivOleh 
- [ ] @shribakb1 
- [ ] @chups98 

## Summary of issue

During error handler implementation TransactionScope  in createStreetcodeHandler was deleted, so now even when stretcode creation failed handler still saves unfinished version of streetcode 

## Summary of change

returned TransactionScope to prevent early save of streetcode

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
